### PR TITLE
Resolve some NU1608 warnings in the das-levy-transfer-matching-api

### DIFF
--- a/src/SFA.DAS.LevyTransferMatching.Api/SFA.DAS.LevyTransferMatching.Api.csproj
+++ b/src/SFA.DAS.LevyTransferMatching.Api/SFA.DAS.LevyTransferMatching.Api.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="5.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="5.0.2" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="10.0.2" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.0" />
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="5.0.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.12.0" />
     <PackageReference Include="Scrutor" Version="3.3.0" />
@@ -31,6 +31,9 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.4" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+	<PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.3.0" />
+	<PackageReference Include="NServiceBus.Persistence.Sql" Version="6.2.0" />
+	<PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@chrisfoster76@cpwevans, I found some NU1608 warnings in the das-levy-transfer-matching-api:

`Warning NU1608 Detected package version outside of dependency constraint: NServiceBus.Persistence.Sql 4.1.1 requires Newtonsoft.Json (>= 11.0.1 && < 12.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`		
`Warning NU1608 Detected package version outside of dependency constraint: NServiceBus.Newtonsoft.Json 2.1.0 requires Newtonsoft.Json (>= 11.0.1 && < 12.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.Azure.ServiceBus 4.0.0 requires System.IdentityModel.Tokens.Jwt (>= 5.4.0 && < 6.0.0)，but version System.IdentityModel.Tokens.Jwt 6.8.0 was resolved.`	
`Warning NU1608 Detected package version outside of dependency constraint: NServiceBus.Persistence.Sql 4.1.1 requires Newtonsoft.Json (>= 11.0.1 && < 12.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: NServiceBus.Newtonsoft.Json 2.1.0 requires Newtonsoft.Json (>= 11.0.1 && < 12.0.0)，but version Newtonsoft.Json 13.0.1 was resolved.`
`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.Azure.ServiceBus 4.0.0 requires System.IdentityModel.Tokens.Jwt (>= 5.4.0 && < 6.0.0)，but version System.IdentityModel.Tokens.Jwt 6.8.0 was resolved.`

This fix can remove this warnings from das-levy-transfer-matching-api's dependency graph.
Hope the PR can help you.

Best regards,
sucrose